### PR TITLE
Added support for using BERT for mask filling.

### DIFF
--- a/examples/hf_bert.py
+++ b/examples/hf_bert.py
@@ -8,15 +8,15 @@ import prewl, json
 # Dynamically detect if the argument is json or a file with json
 prewl.configure({
     'backend': {
-        'service': 'gpt-j-6b',
+        'service': 'bert-base-uncased',
         'remote': True,
         'token': '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' # Use your huggingface token
     },
     'newline-delimited': True, # Should a new line indicate the end of the completion
-    'classes': ['positive', 'negative', 'neutral'], # defaults to None
+    'classes': None, # defaults to None
     'max-length': 3, # output response upper length limit
     'gpu': True, # True or the GPU number you would like to use (if local). False (or -1 if local) indicates CPU,
-    'resp_parser': 'text_gen_parser'
+    'resp_parser': 'mask_fill_parser'
 })
 
 #-----------------------------------------#
@@ -24,18 +24,15 @@ prewl.configure({
 PROMPTS = """
 [
     {
-        "text": "I really don't like this movie.",
-        "sentiment": "negative"
+        "text": "I ate popcorn at the movies."
     },
 
     {
-        "text": "This flick was sick!",
-        "sentiment": "positive"
+        "text": "This flick was sick!"
     },
 
     {
-        "text": "It was ok. I've seen better, though.",
-        "sentiment": "neutral"
+        "text": "It was ok. I've seen better, though."
     }
 ]
 """
@@ -43,12 +40,11 @@ PROMPTS = """
 examples = json.loads(PROMPTS)
 
 PATTERN = """
-Text: {text}
-Sentiment: {sentiment}
+{text}
 """
 
 # Prompts objects
-prompts = prewl.load_prompts(PATTERN, examples, 'sentiment')
+prompts = prewl.load_prompts(PATTERN, examples, 'mask')
 
 
 #-----------------------------------------#
@@ -59,7 +55,7 @@ prompts = prewl.load_prompts(PATTERN, examples, 'sentiment')
 #  (3) returns the parsed result
 model = prewl.train(prompts) # Model object
 
-new_input = "This movie was off the hook!"
+new_input = "This [MASK] was off the hook!"
 resp = model.infer(new_input)
 
 print("\n New input: ", new_input)

--- a/prewl/__init__.py
+++ b/prewl/__init__.py
@@ -19,6 +19,20 @@ def reset_config():
 
 # Set the configuration for the prewl library
 def configure(config):
+    """
+    This method accepts a dictionary with configuration keys and values
+    OR a string filepath to a configuration json file.
+
+    A notable configuration item is the 'resp_parser'
+    string attribute which specified which parser should be used 
+    to parse the response from the model. The one you need will 
+    depend on what LLM model and task you are using. For example,
+    for parsing responses from text generation models, use:
+     'text_gen_parser'
+    and for responses from mask filling models, use:
+     'mask_fill_parser'
+    All available parsers are defined in resp_parsers.py
+    """
     if isinstance(config, str) and os.path.isfile(config):
         with open(config, 'r') as f:
             config = json.load(f)

--- a/prewl/endpoints/__init__.py
+++ b/prewl/endpoints/__init__.py
@@ -7,6 +7,7 @@ huggingface_options = {
     'gpt2': 'gpt2',
     'bloom': 'bigscience/bloom',
     'gpt-j-6b': 'EleutherAI/gpt-j-6B',
+    'bert-base-uncased': 'bert-base-uncased'
 }
 
 def create_endpoint(ep_type, remote):

--- a/prewl/endpoints/resp_parsers.py
+++ b/prewl/endpoints/resp_parsers.py
@@ -7,6 +7,9 @@ parser simply returns the json response.
 """
 
 def text_gen_parser(response, prompt):
+    """
+    A parser for the text generation task.
+    """
     resp = response.json()
     resp = resp[0]['generated_text']
     assert prompt in resp, "Response doesn't contain prompt:\n" % resp
@@ -19,9 +22,15 @@ def text_gen_parser(response, prompt):
     return resp
 
 def mask_fill_parser(response, prompt):
+    """
+    A simple parser for the mask fill task. 
+    No processing is needed, so it just returns the 
+    json from the response.
+    """
     resp = response.json()
-    # assert prompt in resp, "Response doesn't contain prompt:\n" % resp
     return resp
     
-resp_parser_dict = {'text_gen_parser': text_gen_parser,
-'mask_fill_parser': mask_fill_parser}
+resp_parser_dict = {
+    'text_gen_parser': text_gen_parser,
+    'mask_fill_parser': mask_fill_parser
+    }

--- a/prewl/endpoints/resp_parsers.py
+++ b/prewl/endpoints/resp_parsers.py
@@ -1,0 +1,27 @@
+"""
+This file contains functions that take a response from hf
+and they parse out the response for a given task. For example,
+the text_gen_parser collects the result from the first item in the
+response json, and in the 'generated_text' attribute. The mask_fill 
+parser simply returns the json response.
+"""
+
+def text_gen_parser(response, prompt):
+    resp = response.json()
+    resp = resp[0]['generated_text']
+    assert prompt in resp, "Response doesn't contain prompt:\n" % resp
+    resp = resp.split(prompt)[1]
+    
+    from prewl import CONFIG
+    if CONFIG.get('newline-delimited', CONFIG['defaults']['newline-delimited']):
+        resp = resp.split('\n')[0].strip()
+    
+    return resp
+
+def mask_fill_parser(response, prompt):
+    resp = response.json()
+    # assert prompt in resp, "Response doesn't contain prompt:\n" % resp
+    return resp
+    
+resp_parser_dict = {'text_gen_parser': text_gen_parser,
+'mask_fill_parser': mask_fill_parser}

--- a/prewl/prompts.py
+++ b/prewl/prompts.py
@@ -30,7 +30,7 @@ class Prompts(object):
         # Inputs and output are distinct and equal to keys
         assert self.output not in self.inputs, "Output can't be an input"
         # the or mask makes it pass for mask filling task
-        assert self.output is 'mask' or set(self.inputs + [self.output]) == keys, "Inputs and output should equal the keys"
+        assert self.output == 'mask' or set(self.inputs + [self.output]) == keys, "Inputs and output should equal the keys"
 
         # Each key appears only once in the pattern
         for k in keys:
@@ -38,7 +38,7 @@ class Prompts(object):
 
         # Output appears at the very end of the prompt. The or mask clause helps
         # make it pass for mask filling task. 
-        assert self.output is 'mask' or self.pattern.strip()[-len('{'+self.output+'}'):] == '{'+self.output+'}', "Output should appear at the end of the pattern"
+        assert self.output == 'mask' or self.pattern.strip()[-len('{'+self.output+'}'):] == '{'+self.output+'}', "Output should appear at the end of the pattern"
 
 
     def complete(self, prompt_config_entry, include_output=False):

--- a/prewl/prompts.py
+++ b/prewl/prompts.py
@@ -29,14 +29,14 @@ class Prompts(object):
 
         # Inputs and output are distinct and equal to keys
         assert self.output not in self.inputs, "Output can't be an input"
-        assert set(self.inputs + [self.output]) == keys, "Inputs and output should equal the keys"
+        # assert set(self.inputs + [self.output]) == keys, "Inputs and output should equal the keys"
 
         # Each key appears only once in the pattern
         for k in keys:
             assert 1 == self.pattern.count('{'+k+'}'), f"Key {k} should appear exactly once in pattern"
 
         # Output appears at the very end of the prompt
-        assert self.pattern.strip()[-len('{'+self.output+'}'):] == '{'+self.output+'}', "Output should appear at the end of the pattern"
+        # assert self.pattern.strip()[-len('{'+self.output+'}'):] == '{'+self.output+'}', "Output should appear at the end of the pattern"
 
 
     def complete(self, prompt_config_entry, include_output=False):
@@ -48,7 +48,7 @@ class Prompts(object):
 
         """
         if include_output:
-            assert set(self.inputs + [self.output]) == set(prompt_config_entry.keys()), "Inputs and output don't match the keys provided"
+            # assert set(self.inputs + [self.output]) == set(prompt_config_entry.keys()), "Inputs and output don't match the keys provided"
             return self.pattern.format(**prompt_config_entry)
         else:
             assert set(self.inputs) == set(prompt_config_entry.keys()), "Inputs don't match the keys provided"

--- a/prewl/prompts.py
+++ b/prewl/prompts.py
@@ -29,14 +29,16 @@ class Prompts(object):
 
         # Inputs and output are distinct and equal to keys
         assert self.output not in self.inputs, "Output can't be an input"
-        # assert set(self.inputs + [self.output]) == keys, "Inputs and output should equal the keys"
+        # the or mask makes it pass for mask filling task
+        assert self.output is 'mask' or set(self.inputs + [self.output]) == keys, "Inputs and output should equal the keys"
 
         # Each key appears only once in the pattern
         for k in keys:
             assert 1 == self.pattern.count('{'+k+'}'), f"Key {k} should appear exactly once in pattern"
 
-        # Output appears at the very end of the prompt
-        # assert self.pattern.strip()[-len('{'+self.output+'}'):] == '{'+self.output+'}', "Output should appear at the end of the pattern"
+        # Output appears at the very end of the prompt. The or mask clause helps
+        # make it pass for mask filling task. 
+        assert self.output is 'mask' or self.pattern.strip()[-len('{'+self.output+'}'):] == '{'+self.output+'}', "Output should appear at the end of the pattern"
 
 
     def complete(self, prompt_config_entry, include_output=False):

--- a/prewl/prompts.py
+++ b/prewl/prompts.py
@@ -50,7 +50,7 @@ class Prompts(object):
 
         """
         if include_output:
-            # assert set(self.inputs + [self.output]) == set(prompt_config_entry.keys()), "Inputs and output don't match the keys provided"
+            assert self.output == 'mask' or set(self.inputs + [self.output]) == set(prompt_config_entry.keys()), "Inputs and output don't match the keys provided"
             return self.pattern.format(**prompt_config_entry)
         else:
             assert set(self.inputs) == set(prompt_config_entry.keys()), "Inputs don't match the keys provided"


### PR DESCRIPTION
# What
Added support for the model `bert-base-uncased` for mask filling.

# Why
Towards using LLM's to understand the plausibility of conversations in a dialog tree, it would be helpful to be able to use PREWL for mask filling tasks.

# How
This works by sending prompts which are just complete sentences that precede the prompt for which you want inference, to give the model more context.

# Notes
This task does not work perfectly with the intentions and assumptions in the code from the text generation capabilities, but I added it in a way that I think is reasonably maintainable and extensible. 
The HF token in the committed code is invalid. 

# Testing
1. Move both example files into the top level directory
2. Provide your HF access token where necessary
3. Use vscode to run both example files. 
4. They both succeed with response from HF